### PR TITLE
Fixed time.sleep() function in async

### DIFF
--- a/custom_components/airbnk_mqtt/__init__.py
+++ b/custom_components/airbnk_mqtt/__init__.py
@@ -131,9 +131,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     hass.data[DOMAIN] = {AIRBNK_DEVICES: lock_devices}
 
     for component in COMPONENT_TYPES:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+        await hass.config_entries.async_forward_entry_setup(entry, component)
     return True
 
 
@@ -161,8 +159,6 @@ async def async_unload_entry(hass, config_entry):
         await device.mqtt_unsubscribe()
 
     hass.data[DOMAIN].pop(AIRBNK_DEVICES)
-    # if not hass.data[DOMAIN]:
-    #     hass.data.pop(DOMAIN)
     _LOGGER.debug("...done")
     return True
 

--- a/custom_components/airbnk_mqtt/const.py
+++ b/custom_components/airbnk_mqtt/const.py
@@ -1,17 +1,15 @@
 """Constants for Airbnk MQTT integration."""
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_TOKEN,
     CONF_NAME,
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_VOLTAGE,
-    DEVICE_CLASS_SIGNAL_STRENGTH,
     PERCENTAGE,
-    ELECTRIC_POTENTIAL_VOLT,
-    TIME_SECONDS,
+    UnitOfElectricPotential,
+    UnitOfTime,
     SIGNAL_STRENGTH_DECIBELS,
 )
 
@@ -36,7 +34,7 @@ AIRBNK_DATA = "airbnk_data"
 AIRBNK_API = "airbnk_api"
 AIRBNK_DEVICES = "airbnk_devices"
 AIRBNK_DISCOVERY_NEW = "airbnk_discovery_new_{}"
-DEFAULT_RETRIES_NUM = 0
+DEFAULT_RETRIES_NUM = 10
 
 TIMEOUT = 60
 

--- a/custom_components/airbnk_mqtt/cover.py
+++ b/custom_components/airbnk_mqtt/cover.py
@@ -1,7 +1,7 @@
 """Support for Airbnk locks, treated as covers."""
 import logging
 
-from homeassistant.components.cover import SUPPORT_CLOSE, SUPPORT_OPEN, CoverEntity
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 
 from .const import (
     DOMAIN as AIRBNK_DOMAIN,
@@ -64,8 +64,7 @@ class AirbnkLock(CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
-        return supported_features
+        return CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
     @property
     def unique_id(self):
@@ -108,7 +107,7 @@ class AirbnkLock(CoverEntity):
         """Return if the cover is closed or not."""
         return None
 
-    async def async_open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs): 
         """Open the cover."""
         if self._device.curr_state == LOCK_STATE_OPERATING:
             _LOGGER.warning("Operation already in progress: please wait")
@@ -118,7 +117,7 @@ class AirbnkLock(CoverEntity):
         _LOGGER.debug("Launching command to open")
         await self._device.operateLock(1)
 
-    async def async_close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs): 
         """Close cover."""
         if self._device.curr_state == LOCK_STATE_OPERATING:
             _LOGGER.warning("Operation already in progress: please wait")

--- a/custom_components/airbnk_mqtt/gra.txt
+++ b/custom_components/airbnk_mqtt/gra.txt
@@ -1,0 +1,132 @@
+Napi csúcstelj:
+WITH daily_max AS (
+    SELECT 
+        DATE_FORMAT(FROM_UNIXTIME(start_ts), '%y-%m-%d') AS date,
+        start_ts,
+        CASE 
+            WHEN metadata_id = 13 THEN max * 1000
+            ELSE max
+        END AS adjusted_max
+    FROM (
+        SELECT start_ts, max, metadata_id
+        FROM homeassistant.statistics
+        WHERE metadata_id = 11
+            AND max IS NOT NULL
+            AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+        UNION ALL
+
+        SELECT start_ts, max, metadata_id
+        FROM homeassistant.statistics_short_term
+        WHERE metadata_id = 11
+            AND max IS NOT NULL
+            AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+        UNION ALL
+
+        SELECT start_ts, max, metadata_id
+        FROM homeassistant_old.statistics
+        WHERE metadata_id = 13
+            AND max IS NOT NULL
+            AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+        UNION ALL
+
+        SELECT start_ts, max, metadata_id
+        FROM homeassistant_old.statistics_short_term
+        WHERE metadata_id = 13
+            AND max IS NOT NULL
+            AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+    ) combined_data
+),
+ranked_max AS (
+    SELECT 
+        date,
+        start_ts,
+        adjusted_max,
+        ROW_NUMBER() OVER (PARTITION BY date ORDER BY adjusted_max DESC) AS rank
+    FROM daily_max
+)
+SELECT 
+    date,
+    DATE_FORMAT(FROM_UNIXTIME(start_ts), '%H:%i:%s') AS datetime,
+    adjusted_max AS "Csúcsteljesítmény"
+FROM ranked_max
+WHERE rank = 1
+ORDER BY date ASC;
+
+Napi csúcsteljesítmény ${__from:date:YY.MM.DD} és ${__to:date:YY.MM.DD} között
+---------------
+Napi áramfogyasztás
+
+SELECT 
+   DATE_FORMAT(FROM_UNIXTIME(start_ts), '%Y-%m-%d') AS day,
+    MAX(state) - MIN(state) AS "Napi fogyasztás"
+FROM (
+    SELECT start_ts, state
+    FROM homeassistant.statistics
+    WHERE metadata_id = 9
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+    UNION ALL
+
+    SELECT start_ts, state
+    FROM homeassistant.statistics_short_term
+    WHERE metadata_id = 9
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+    UNION ALL
+
+    SELECT start_ts, state
+    FROM homeassistant_old.statistics
+    WHERE metadata_id = 11
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+    UNION ALL
+
+    SELECT start_ts, state
+    FROM homeassistant_old.statistics_short_term
+    WHERE metadata_id = 11
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+) combined_data
+GROUP BY DATE_FORMAT(FROM_UNIXTIME(start_ts), '%Y-%m-%d')
+ORDER BY day;
+
+
+Időszaki fogyasztás ${idoszaki_fogyasztas} kWh (${__from:date:YY.MM.DD} - ${__to:date:YY.MM.DD})
+-------------------------
+
+Teljesítményfelvétel
+SELECT 
+    FROM_UNIXTIME(start_ts),
+    CONVERT_TZ(FROM_UNIXTIME(start_ts), '+00:00', '-01:00'),
+    max AS "Csúcsteljesítmény",
+    mean AS "Átlagteljesítmény"
+FROM (
+    SELECT start_ts, max, mean
+    FROM homeassistant.statistics
+    WHERE metadata_id = 11
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+    UNION ALL
+
+    SELECT start_ts, max, mean
+    FROM homeassistant.statistics_short_term
+    WHERE metadata_id = 11
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+    UNION ALL
+
+    SELECT start_ts, max * 1000 AS max, mean * 1000 AS mean
+    FROM homeassistant_old.statistics
+    WHERE metadata_id = 13
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+
+    UNION ALL
+
+    SELECT start_ts, max * 1000 AS max, mean * 1000 AS mean
+    FROM homeassistant_old.statistics_short_term
+    WHERE metadata_id = 13
+        AND FROM_UNIXTIME(start_ts) BETWEEN $__timeFrom() AND $__timeTo()
+) combined_data
+ORDER BY start_ts;

--- a/custom_components/airbnk_mqtt/sensor.py
+++ b/custom_components/airbnk_mqtt/sensor.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import logging
 
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import SensorDeviceClass
 
 from homeassistant.const import (
-    CONF_DEVICE_CLASS,
     CONF_ICON,
     CONF_NAME,
     CONF_TYPE,
@@ -106,7 +106,7 @@ class AirbnkSensor(Entity):
     @property
     def device_class(self):
         """Return the class of this device."""
-        return self._sensor.get(CONF_DEVICE_CLASS)
+        return self._sensor.get("device_class")
 
     @property
     def icon(self):
@@ -129,7 +129,6 @@ class AirbnkBatterySensor(AirbnkSensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        # print("VOLT: {} {}".format(self._monitored_attribute, self._device._lockData))
         self._device.check_availability()
         if self._monitored_attribute in self._device._lockData:
             return self._device._lockData[self._monitored_attribute]

--- a/custom_components/airbnk_mqtt/tasmota_device.py
+++ b/custom_components/airbnk_mqtt/tasmota_device.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import base64
 import json
 import time
+import asyncio
 from typing import Callable
 
 from cryptography.hazmat.backends import default_backend
@@ -279,7 +280,7 @@ class TasmotaMqttLockDevice:
 
                 if self.curr_try < self.retries_num:
                     self.curr_try += 1
-                    time.sleep(0.5)
+                    await asyncio.sleep(0.5)
                     self.logger.debug("Retrying: attempt %i" % self.curr_try)
                     self.curr_state = LOCK_STATE_OPERATING
                     for callback_func in self._callbacks:


### PR DESCRIPTION
**Issue Description**
The original issue occurred in the airbnk_mqtt custom Home Assistant integration when handling MQTT messages for a Tasmota-based lock device. The log contained the following error:

RuntimeError: Caught blocking call to sleep with args (0.5,) inside the event loop by custom integration 'airbnk_mqtt' at custom_components/airbnk_mqtt/tasmota_device.py, line XXX

The problem was caused by the use of the time.sleep() function in an asynchronous context (async def). Blocking calls like time.sleep() are not allowed in asynchronous environments in Home Assistant as they can freeze the event loop.

**Solution**
The solution was to replace the blocking time.sleep() function with the asynchronous await asyncio.sleep() function.

_Example of the Fix:_
Before:

if self.curr_try < self.retries_num:
    self.curr_try += 1
    time.sleep(0.5)  # Blocking call that caused the error
    self.logger.debug("Retrying: attempt %i" % self.curr_try)
After:

if self.curr_try < self.retries_num:
    self.curr_try += 1
    await asyncio.sleep(0.5)  # Non-blocking, asynchronous sleep
    self.logger.debug("Retrying: attempt %i" % self.curr_try)
This modification ensures that the integration adheres to the non-blocking, asynchronous principles of Home Assistant's core framework.

**Additional Context**
The issue was specifically related to the retry logic in the async_parse_MQTT_message method, which attempts to resend frames after a failed connection (state: FAILCONNECT). The fix allows the integration to handle such failures gracefully without impacting the Home Assistant event loop.

**2025 HA compatibility:**

_Replaced Deprecated Constants:_

Replaced DEVICE_CLASS_SIGNAL_STRENGTH, ELECTRIC_POTENTIAL_VOLT, and TIME_SECONDS with: SensorDeviceClass.SIGNAL_STRENGTH
UnitOfElectricPotential.VOLT
UnitOfTime.SECONDS
Updated Cover Entity Constants:

_Replaced SUPPORT_CLOSE and SUPPORT_OPEN with:_
CoverEntityFeature.CLOSE
CoverEntityFeature.OPEN
Fixed async_forward_entry_setup Usage:

Added await before all async_forward_entry_setup calls to ensure proper asynchronous execution and to comply with Home Assistant 2025.1 requirements. Ensured Compatibility with Future Home Assistant Versions:

Addressed all deprecation warnings and updated the code to align with Home Assistant's latest API standards.